### PR TITLE
Proper error handling with current SassMeister API

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -42,7 +42,13 @@ class SM
       raise Error.new "Unexpected #{type} response from SassMeister", response
     end
 
-    JSON.parse(response.body)['css']
+    data = JSON.parse(response.body)
+
+    if not data.has_key?('css')
+      raise Error.new "SassMeister returned an error: #{data['message']}", response
+    end
+
+    data['css']
   end
 
   #


### PR DESCRIPTION
SassMeister can now return JSON error responses, and the Rakefile was expecting all JSON responses to be success responses with a `css` key.

Now if a response have no `css` key, an error is thrown with the `message` key (error message from SassMeister).