### PR TITLE
[WIP] Use local docker containers instead of Sassmeister

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -68,6 +68,10 @@ class String
     gsub(/^/, ' ' * n)
   end
 
+  def normalize_encoding
+    self.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
+  end
+
   def normalize_css
     self[/^@charset/]
   end
@@ -85,6 +89,7 @@ class String
   #
   def clean
     lines
+      .map(&:normalize_encoding)
       .reject(&:normalize_css)
       .reject(&:normalize_libsass_error_messages)
       .reject(&:normalize_errors_messages)

--- a/Rakefile
+++ b/Rakefile
@@ -195,11 +195,6 @@ STATS_SCSS = '_sass/utils/_stats.scss'
 #
 SUPPORT = '_data/support.yml'
 
-#
-# Mutex to synchronize before printing during parallel tasks.
-#
-MUTEX = Mutex.new
-
 task :default => [STATS_SCSS]
 
 #
@@ -259,7 +254,7 @@ end
 # From each individual test support file, build the aggregated YAML
 # file.
 #
-multitask SUPPORT => TESTS.map { |t| "#{t}/support.yml" } do |t|
+task SUPPORT => TESTS.map { |t| "#{t}/support.yml" } do |t|
   File.open(t.name, 'w') do |file|
     SPEC.each do |name, tests|
       feature = {}
@@ -334,16 +329,12 @@ TESTS.each do |test|
         .find { |f| File.exist? f }
 
 
-      MUTEX.synchronize do
-        puts "#{Progress.inc_s} Compiling #{input} for #{engine}"
-      end
+      puts "#{Progress.inc_s} Compiling #{input} for #{engine}"
 
       begin
         File.write t.name, SM[endpoint].compile(input).clean
       rescue SM::Error => e
-        MUTEX.synchronize do
-          STDERR.puts "  #{e} with #{input} for #{engine}"
-        end
+        STDERR.puts "  #{e} with #{input} for #{engine}"
 
         File.write t.name, e.response.body
       end

--- a/Rakefile
+++ b/Rakefile
@@ -99,6 +99,7 @@ ENGINES = {
   :ruby_sass_3_3 => '3_3',
   :ruby_sass_3_4 => '3_4',
   :libsass_3_1 => 'libsass_3_1',
+  :libsass_3_2 => 'libsass_3_2',
 }
 
 #
@@ -120,6 +121,7 @@ ENGINE_EXEC = {
   :ruby_sass_3_3 => nil,
   :ruby_sass_3_4 => nil,
   :libsass_3_1 => nil,
+  :libsass_3_2 => nil,
 }
 
 #

--- a/_data/engines.yml
+++ b/_data/engines.yml
@@ -7,6 +7,6 @@ ruby_sass_3_3:
 ruby_sass_3_4:
   label: Ruby Sass 3.4
   link: https://github.com/sass/sass/releases/tag/3.4.0
-libsass:
-  label: LibSass
-  link: https://github.com/sass/libsass
+libsass_3_1:
+  label: LibSass 3.1
+  link: https://github.com/sass/libsass/releases/tag/3.1.0

--- a/_data/issues.yml
+++ b/_data/issues.yml
@@ -1,12 +1,12 @@
 angle_conversion:
     ruby_sass_3_2: https://github.com/sass/sass/issues/1338
     ruby_sass_3_3: https://github.com/sass/sass/issues/1338
-    libsass: https://github.com/sass/libsass/issues/666
+    libsass_3_1: https://github.com/sass/libsass/issues/666
 
 at_root_directive:
     ruby_sass_3_2: https://github.com/sass/sass/issues/774
     ruby_sass_3_3: https://github.com/sass/sass-spec/pull/59#issuecomment-66930658
-    libsass: https://github.com/sass/libsass/issues/353
+    libsass_3_1: https://github.com/sass/libsass/issues/353
 
 call_function:
     ruby_sass_3_2: https://github.com/sass/sass/issues/626
@@ -15,29 +15,29 @@ cross_media_extend:
     ruby_sass_3_2: https://github.com/sass/sass/issues/640
     ruby_sass_3_3: https://github.com/sass/sass/issues/640
     ruby_sass_3_4: https://github.com/sass/sass/issues/640
-    libsass: https://github.com/sass/libsass/issues/712
+    libsass_3_1: https://github.com/sass/libsass/issues/712
 
 deep_extend:
-    libsass: https://github.com/sass/libsass/issues/592
+    libsass_3_1: https://github.com/sass/libsass/issues/592
 
 downward_for:
     ruby_sass_3_2: https://github.com/sass/sass/issues/691
-    libsass: https://github.com/sass/libsass/issues/703
+    libsass_3_1: https://github.com/sass/libsass/issues/703
 
 error_directive:
     ruby_sass_3_2: https://github.com/sass/sass/issues/747
     ruby_sass_3_3: https://github.com/sass/sass/issues/747
-    libsass: https://github.com/sass/libsass/issues/704
+    libsass_3_1: https://github.com/sass/libsass/issues/704
 
 feature_detection_functions:
-    libsass: https://github.com/sass/libsass/issues/702
+    libsass_3_1: https://github.com/sass/libsass/issues/702
 
 fixed_if_function:
     ruby_sass_3_2: https://github.com/sass/sass/pull/836
 
 inspect_function:
     ruby_sass_3_2: https://github.com/sass/sass/issues/953
-    libsass: https://github.com/sass/libsass/issues/701
+    libsass_3_1: https://github.com/sass/libsass/issues/701
 
 list_separator_function:
     ruby_sass_3_2: https://github.com/sass/sass/pull/689
@@ -46,7 +46,7 @@ map_data_type:
     ruby_sass_3_2: https://github.com/sass/sass/issues/642
 
 media_merge:
-    libsass: https://github.com/sass/libsass/issues/185
+    libsass_3_1: https://github.com/sass/libsass/issues/185
 
 multi_assign_each:
     ruby_sass_3_2: https://github.com/sass/sass/issues/1262
@@ -59,40 +59,40 @@ negative_indexes:
     ruby_sass_3_2: https://github.com/sass/sass/pull/808
 
 nested_interpolations:
-    libsass: https://github.com/sass/libsass/issues/615
+    libsass_3_1: https://github.com/sass/libsass/issues/615
 
 random_function:
     ruby_sass_3_2: https://github.com/sass/sass/pull/968
-    libsass: https://github.com/sass/libsass/issues/657
+    libsass_3_1: https://github.com/sass/libsass/issues/657
 
 rebeccapurple_color:
     ruby_sass_3_2: https://github.com/sass/sass/issues/1293
     ruby_sass_3_3: https://github.com/sass/sass/issues/1293
-    libsass: https://github.com/sass/libsass/issues/699
+    libsass_3_1: https://github.com/sass/libsass/issues/699
 
 reserved_function_names:
-    libsass: https://github.com/sass/libsass/issues/713
+    libsass_3_1: https://github.com/sass/libsass/issues/713
 
 set_nth_function:
     ruby_sass_3_2: https://github.com/sass/sass/issues/852
 
 shadow_dom_styling:
-    libsass: https://github.com/sass/libsass/issues/452
+    libsass_3_1: https://github.com/sass/libsass/issues/452
 
 spaces_minus:
-    libsass: https://github.com/sass/libsass/issues/733
+    libsass_3_1: https://github.com/sass/libsass/issues/733
 
 string_manipulation_functions:
     ruby_sass_3_2: https://github.com/sass/sass/pull/401
-    libsass: https://github.com/sass/libsass/issues/381#issuecomment-66935725
+    libsass_3_1: https://github.com/sass/libsass/issues/381#issuecomment-66935725
 
 transparent_color:
     ruby_sass_3_2: https://github.com/sass/sass/issues/754
-    libsass: https://github.com/sass/libsass/issues/700
+    libsass_3_1: https://github.com/sass/libsass/issues/700
 
 unique_id_function:
     ruby_sass_3_2: https://github.com/sass/sass/issues/771
-    libsass: https://github.com/sass/libsass/issues/636
+    libsass_3_1: https://github.com/sass/libsass/issues/636
 
 variable_scoping:
-    libsass: https://github.com/sass/libsass/issues/613
+    libsass_3_1: https://github.com/sass/libsass/issues/613

--- a/_data/issues.yml
+++ b/_data/issues.yml
@@ -2,11 +2,13 @@ angle_conversion:
     ruby_sass_3_2: https://github.com/sass/sass/issues/1338
     ruby_sass_3_3: https://github.com/sass/sass/issues/1338
     libsass_3_1: https://github.com/sass/libsass/issues/666
+    libsass_3_2: https://github.com/sass/libsass/issues/666
 
 at_root_directive:
     ruby_sass_3_2: https://github.com/sass/sass/issues/774
     ruby_sass_3_3: https://github.com/sass/sass-spec/pull/59#issuecomment-66930658
     libsass_3_1: https://github.com/sass/libsass/issues/353
+    libsass_3_2: https://github.com/sass/libsass/issues/353
 
 call_function:
     ruby_sass_3_2: https://github.com/sass/sass/issues/626
@@ -16,21 +18,26 @@ cross_media_extend:
     ruby_sass_3_3: https://github.com/sass/sass/issues/640
     ruby_sass_3_4: https://github.com/sass/sass/issues/640
     libsass_3_1: https://github.com/sass/libsass/issues/712
+    libsass_3_2: https://github.com/sass/libsass/issues/712
 
 deep_extend:
     libsass_3_1: https://github.com/sass/libsass/issues/592
+    libsass_3_2: https://github.com/sass/libsass/issues/592
 
 downward_for:
     ruby_sass_3_2: https://github.com/sass/sass/issues/691
     libsass_3_1: https://github.com/sass/libsass/issues/703
+    libsass_3_2: https://github.com/sass/libsass/issues/703
 
 error_directive:
     ruby_sass_3_2: https://github.com/sass/sass/issues/747
     ruby_sass_3_3: https://github.com/sass/sass/issues/747
     libsass_3_1: https://github.com/sass/libsass/issues/704
+    libsass_3_2: https://github.com/sass/libsass/issues/704
 
 feature_detection_functions:
     libsass_3_1: https://github.com/sass/libsass/issues/702
+    libsass_3_2: https://github.com/sass/libsass/issues/702
 
 fixed_if_function:
     ruby_sass_3_2: https://github.com/sass/sass/pull/836
@@ -38,6 +45,7 @@ fixed_if_function:
 inspect_function:
     ruby_sass_3_2: https://github.com/sass/sass/issues/953
     libsass_3_1: https://github.com/sass/libsass/issues/701
+    libsass_3_2: https://github.com/sass/libsass/issues/701
 
 list_separator_function:
     ruby_sass_3_2: https://github.com/sass/sass/pull/689
@@ -47,6 +55,7 @@ map_data_type:
 
 media_merge:
     libsass_3_1: https://github.com/sass/libsass/issues/185
+    libsass_3_2: https://github.com/sass/libsass/issues/185
 
 multi_assign_each:
     ruby_sass_3_2: https://github.com/sass/sass/issues/1262
@@ -60,39 +69,49 @@ negative_indexes:
 
 nested_interpolations:
     libsass_3_1: https://github.com/sass/libsass/issues/615
+    libsass_3_2: https://github.com/sass/libsass/issues/615
 
 random_function:
     ruby_sass_3_2: https://github.com/sass/sass/pull/968
     libsass_3_1: https://github.com/sass/libsass/issues/657
+    libsass_3_2: https://github.com/sass/libsass/issues/657
 
 rebeccapurple_color:
     ruby_sass_3_2: https://github.com/sass/sass/issues/1293
     ruby_sass_3_3: https://github.com/sass/sass/issues/1293
     libsass_3_1: https://github.com/sass/libsass/issues/699
+    libsass_3_2: https://github.com/sass/libsass/issues/699
 
 reserved_function_names:
     libsass_3_1: https://github.com/sass/libsass/issues/713
+    libsass_3_2: https://github.com/sass/libsass/issues/713
 
 set_nth_function:
     ruby_sass_3_2: https://github.com/sass/sass/issues/852
 
 shadow_dom_styling:
     libsass_3_1: https://github.com/sass/libsass/issues/452
+    libsass_3_2: https://github.com/sass/libsass/issues/452
 
 spaces_minus:
     libsass_3_1: https://github.com/sass/libsass/issues/733
+    libsass_3_2: https://github.com/sass/libsass/issues/733
 
 string_manipulation_functions:
     ruby_sass_3_2: https://github.com/sass/sass/pull/401
     libsass_3_1: https://github.com/sass/libsass/issues/381#issuecomment-66935725
+    libsass_3_2: https://github.com/sass/libsass/issues/381#issuecomment-66935725
 
 transparent_color:
     ruby_sass_3_2: https://github.com/sass/sass/issues/754
     libsass_3_1: https://github.com/sass/libsass/issues/700
+    libsass_3_2: https://github.com/sass/libsass/issues/700
 
 unique_id_function:
     ruby_sass_3_2: https://github.com/sass/sass/issues/771
     libsass_3_1: https://github.com/sass/libsass/issues/636
+    libsass_3_2: https://github.com/sass/libsass/issues/636
 
 variable_scoping:
     libsass_3_1: https://github.com/sass/libsass/issues/613
+    libsass_3_2: https://github.com/sass/libsass/issues/613

--- a/_data/stats.yml
+++ b/_data/stats.yml
@@ -14,3 +14,7 @@ libsass_3_1:
   passed: 32
   failed: 36
   percentage: 47.06
+libsass_3_2:
+  passed: 60
+  failed: 8
+  percentage: 88.24

--- a/_data/stats.yml
+++ b/_data/stats.yml
@@ -3,14 +3,14 @@ ruby_sass_3_2:
   failed: 60
   percentage: 11.76
 ruby_sass_3_3:
-  passed: 60
-  failed: 8
-  percentage: 88.24
+  passed: 54
+  failed: 14
+  percentage: 79.41
 ruby_sass_3_4:
-  passed: 68
-  failed: 0
-  percentage: 100.0
-libsass:
-  passed: 34
-  failed: 34
-  percentage: 50.0
+  passed: 63
+  failed: 5
+  percentage: 92.65
+libsass_3_1:
+  passed: 32
+  failed: 36
+  percentage: 47.06

--- a/_data/stats.yml
+++ b/_data/stats.yml
@@ -7,14 +7,14 @@ ruby_sass_3_3:
   failed: 14
   percentage: 79.41
 ruby_sass_3_4:
+  passed: 68
+  failed: 0
+  percentage: 100.0
+libsass_3_1:
+  passed: 33
+  failed: 35
+  percentage: 48.53
+libsass_3_2:
   passed: 63
   failed: 5
   percentage: 92.65
-libsass_3_1:
-  passed: 32
-  failed: 36
-  percentage: 47.06
-libsass_3_2:
-  passed: 60
-  failed: 8
-  percentage: 88.24

--- a/_data/support.yml
+++ b/_data/support.yml
@@ -11,7 +11,7 @@ ampersand_sassscript:
     support: true
     tests:
       tests/ampersand_sassscript: true
-  libsass:
+  libsass_3_1:
     support: false
     tests:
       tests/ampersand_sassscript: false
@@ -29,7 +29,7 @@ angle_conversion:
     support: true
     tests:
       spec/libsass-closed-issues/issue_666/angle: true
-  libsass:
+  libsass_3_1:
     support: true
     tests:
       spec/libsass-closed-issues/issue_666/angle: true
@@ -92,7 +92,7 @@ at_root_directive:
       spec/libsass/at-root/141_test_at_root_with_parent_ref: true
       spec/libsass/at-root/142_test_multi_level_at_root_with_parent_ref: true
       spec/libsass/at-root/143_test_multi_level_at_root_with_inner_parent_ref: true
-  libsass:
+  libsass_3_1:
     support: false
     tests:
       spec/libsass/at-root/ampersand: false
@@ -125,7 +125,7 @@ call_function:
     support: true
     tests:
       spec/basic/60_call: true
-  libsass:
+  libsass_3_1:
     support: true
     tests:
       spec/basic/60_call: true
@@ -136,14 +136,14 @@ cross_media_extend:
     tests:
       tests/cross_media_extend: false
   ruby_sass_3_3:
-    support: true
+    support: false
     tests:
-      tests/cross_media_extend: true
+      tests/cross_media_extend: false
   ruby_sass_3_4:
-    support: true
+    support: false
     tests:
-      tests/cross_media_extend: true
-  libsass:
+      tests/cross_media_extend: false
+  libsass_3_1:
     support: false
     tests:
       tests/cross_media_extend: false
@@ -152,19 +152,19 @@ deep_extend:
   ruby_sass_3_2:
     support: true
     tests:
-      spec/libsass-todo-issues/issue_592: true
+      spec/libsass-closed-issues/issue_592: true
   ruby_sass_3_3:
     support: true
     tests:
-      spec/libsass-todo-issues/issue_592: true
+      spec/libsass-closed-issues/issue_592: true
   ruby_sass_3_4:
     support: true
     tests:
-      spec/libsass-todo-issues/issue_592: true
-  libsass:
+      spec/libsass-closed-issues/issue_592: true
+  libsass_3_1:
     support: false
     tests:
-      spec/libsass-todo-issues/issue_592: false
+      spec/libsass-closed-issues/issue_592: false
 
 downward_for:
   ruby_sass_3_2:
@@ -179,7 +179,7 @@ downward_for:
     support: true
     tests:
       spec/libsass-closed-issues/issue_703: true
-  libsass:
+  libsass_3_1:
     support: true
     tests:
       spec/libsass-closed-issues/issue_703: true
@@ -194,10 +194,10 @@ error_directive:
     tests:
       tests/error_directive: false
   ruby_sass_3_4:
-    support: true
+    support: false
     tests:
-      tests/error_directive: true
-  libsass:
+      tests/error_directive: false
+  libsass_3_1:
     support: false
     tests:
       tests/error_directive: false
@@ -227,7 +227,7 @@ feature_detection_functions:
       spec/basic/56_global_variable_exists: true
       spec/basic/57_function_exists: true
       spec/basic/58_mixin_exists: true
-  libsass:
+  libsass_3_1:
     support: true
     tests:
       spec/libsass-closed-issues/issue_702: true
@@ -249,7 +249,7 @@ fixed_if_function:
     support: true
     tests:
       spec/libsass-closed-issues/issue_338: true
-  libsass:
+  libsass_3_1:
     support: true
     tests:
       spec/libsass-closed-issues/issue_338: true
@@ -267,7 +267,7 @@ inspect_function:
     support: true
     tests:
       spec/libsass-closed-issues/issue_701: true
-  libsass:
+  libsass_3_1:
     support: true
     tests:
       spec/libsass-closed-issues/issue_701: true
@@ -285,7 +285,7 @@ list_separator_function:
     support: true
     tests:
       spec/libsass-closed-issues/issue_506: true
-  libsass:
+  libsass_3_1:
     support: true
     tests:
       spec/libsass-closed-issues/issue_506: true
@@ -318,7 +318,7 @@ map_data_type:
       spec/maps/map-merge: true
       spec/maps/map-remove: true
       spec/maps/map-values: true
-  libsass:
+  libsass_3_1:
     support: true
     tests:
       spec/maps/map-get: true
@@ -356,7 +356,7 @@ media_merge:
       spec/libsass-closed-issues/issue_185/merge_no_repeat: true
       spec/libsass-closed-issues/issue_185/mixin: true
       spec/libsass-closed-issues/issue_185/selector_wrapper_media: true
-  libsass:
+  libsass_3_1:
     support: false
     tests:
       spec/libsass-closed-issues/issue_185/hoisting: false
@@ -379,7 +379,7 @@ multi_assign_each:
     support: true
     tests:
       spec/libsass-closed-issues/issue_492: true
-  libsass:
+  libsass_3_1:
     support: true
     tests:
       spec/libsass-closed-issues/issue_492: true
@@ -397,7 +397,7 @@ multi_keys_map_remove:
     support: true
     tests:
       spec/libsass-closed-issues/issue_510: true
-  libsass:
+  libsass_3_1:
     support: true
     tests:
       spec/libsass-closed-issues/issue_510: true
@@ -415,7 +415,7 @@ negative_indexes:
     support: true
     tests:
       spec/libsass-closed-issues/issue_224: true
-  libsass:
+  libsass_3_1:
     support: true
     tests:
       spec/libsass-closed-issues/issue_224: true
@@ -424,19 +424,19 @@ nested_interpolations:
   ruby_sass_3_2:
     support: true
     tests:
-      spec/libsass-todo-issues/issue_615: true
+      spec/libsass-closed-issues/issue_615: true
   ruby_sass_3_3:
     support: true
     tests:
-      spec/libsass-todo-issues/issue_615: true
+      spec/libsass-closed-issues/issue_615: true
   ruby_sass_3_4:
     support: true
     tests:
-      spec/libsass-todo-issues/issue_615: true
-  libsass:
+      spec/libsass-closed-issues/issue_615: true
+  libsass_3_1:
     support: false
     tests:
-      spec/libsass-todo-issues/issue_615: false
+      spec/libsass-closed-issues/issue_615: false
 
 random_function:
   ruby_sass_3_2:
@@ -445,20 +445,20 @@ random_function:
       spec/libsass-closed-issues/issue_657/limit: false
       spec/libsass-closed-issues/issue_657/default: false
   ruby_sass_3_3:
-    support: true
+    support: false
     tests:
-      spec/libsass-closed-issues/issue_657/limit: true
-      spec/libsass-closed-issues/issue_657/default: true
+      spec/libsass-closed-issues/issue_657/limit: false
+      spec/libsass-closed-issues/issue_657/default: false
   ruby_sass_3_4:
     support: true
     tests:
       spec/libsass-closed-issues/issue_657/limit: true
       spec/libsass-closed-issues/issue_657/default: true
-  libsass:
-    support: true
+  libsass_3_1:
+    support: 
     tests:
       spec/libsass-closed-issues/issue_657/limit: true
-      spec/libsass-closed-issues/issue_657/default: true
+      spec/libsass-closed-issues/issue_657/default: false
 
 rebeccapurple_color:
   ruby_sass_3_2:
@@ -473,7 +473,7 @@ rebeccapurple_color:
     support: true
     tests:
       spec/libsass-closed-issues/issue_699: true
-  libsass:
+  libsass_3_1:
     support: true
     tests:
       spec/libsass-closed-issues/issue_699: true
@@ -486,23 +486,23 @@ reserved_function_names:
       tests/reserved_function_names/and: false
       tests/reserved_function_names/or: false
   ruby_sass_3_3:
-    support: true
+    support: false
     tests:
-      tests/reserved_function_names/not: true
-      tests/reserved_function_names/and: true
-      tests/reserved_function_names/or: true
+      tests/reserved_function_names/not: false
+      tests/reserved_function_names/and: false
+      tests/reserved_function_names/or: false
   ruby_sass_3_4:
-    support: true
+    support: false
     tests:
-      tests/reserved_function_names/not: true
-      tests/reserved_function_names/and: true
-      tests/reserved_function_names/or: true
-  libsass:
-    support: true
+      tests/reserved_function_names/not: false
+      tests/reserved_function_names/and: false
+      tests/reserved_function_names/or: false
+  libsass_3_1:
+    support: false
     tests:
-      tests/reserved_function_names/not: true
-      tests/reserved_function_names/and: true
-      tests/reserved_function_names/or: true
+      tests/reserved_function_names/not: false
+      tests/reserved_function_names/and: false
+      tests/reserved_function_names/or: false
 
 selector_manipulation_functions:
   ruby_sass_3_2:
@@ -517,7 +517,7 @@ selector_manipulation_functions:
     support: true
     tests:
       tests/selector_manipulation_functions: true
-  libsass:
+  libsass_3_1:
     support: false
     tests:
       tests/selector_manipulation_functions: false
@@ -535,7 +535,7 @@ set_nth_function:
     support: true
     tests:
       spec/libsass-closed-issues/issue_578: true
-  libsass:
+  libsass_3_1:
     support: true
     tests:
       spec/libsass-closed-issues/issue_578: true
@@ -553,7 +553,7 @@ shadow_dom_styling:
     support: true
     tests:
       tests/shadow_dom_styling: true
-  libsass:
+  libsass_3_1:
     support: false
     tests:
       tests/shadow_dom_styling: false
@@ -571,7 +571,7 @@ spaces_minus:
     support: true
     tests:
       spec/libsass-closed-issues/issue_733: true
-  libsass:
+  libsass_3_1:
     support: false
     tests:
       spec/libsass-closed-issues/issue_733: false
@@ -610,17 +610,17 @@ string_manipulation_functions:
       spec/libsass-closed-issues/issue_760: true
       spec/libsass-closed-issues/issue_763: true
       spec/libsass-closed-issues/issue_815: true
-  libsass:
+  libsass_3_1:
     support: 
     tests:
       spec/basic/43_str_length: true
       spec/basic/45_str_insert: true
       spec/basic/46_str_index: true
       spec/basic/48_case_conversion: true
-      spec/libsass-todo-tests/47_str_slice: false
-      spec/libsass-closed-issues/issue_760: false
-      spec/libsass-closed-issues/issue_763: false
-      spec/libsass-closed-issues/issue_815: true
+      spec/libsass-todo-tests/47_str_slice: true
+      spec/libsass-closed-issues/issue_760: true
+      spec/libsass-closed-issues/issue_763: true
+      spec/libsass-closed-issues/issue_815: false
 
 transparent_color:
   ruby_sass_3_2:
@@ -635,7 +635,7 @@ transparent_color:
     support: true
     tests:
       spec/libsass-closed-issues/issue_700: true
-  libsass:
+  libsass_3_1:
     support: true
     tests:
       spec/libsass-closed-issues/issue_700: true
@@ -653,7 +653,7 @@ unique_id_function:
     support: true
     tests:
       spec/libsass-closed-issues/issue_636: true
-  libsass:
+  libsass_3_1:
     support: true
     tests:
       spec/libsass-closed-issues/issue_636: true
@@ -662,17 +662,17 @@ variable_scoping:
   ruby_sass_3_2:
     support: false
     tests:
-      spec/libsass-todo-issues/issue_613: false
+      spec/libsass-closed-issues/issue_613: false
   ruby_sass_3_3:
     support: false
     tests:
-      spec/libsass-todo-issues/issue_613: false
+      spec/libsass-closed-issues/issue_613: false
   ruby_sass_3_4:
     support: true
     tests:
-      spec/libsass-todo-issues/issue_613: true
-  libsass:
+      spec/libsass-closed-issues/issue_613: true
+  libsass_3_1:
     support: false
     tests:
-      spec/libsass-todo-issues/issue_613: false
+      spec/libsass-closed-issues/issue_613: false
 

--- a/_data/support.yml
+++ b/_data/support.yml
@@ -171,9 +171,9 @@ cross_media_extend:
     tests:
       tests/cross_media_extend: false
   ruby_sass_3_4:
-    support: false
+    support: true
     tests:
-      tests/cross_media_extend: false
+      tests/cross_media_extend: true
   libsass_3_1:
     support: false
     tests:
@@ -237,13 +237,13 @@ error_directive:
     tests:
       tests/error_directive: false
   ruby_sass_3_4:
-    support: false
+    support: true
     tests:
-      tests/error_directive: false
+      tests/error_directive: true
   libsass_3_1:
-    support: false
+    support: true
     tests:
-      tests/error_directive: false
+      tests/error_directive: true
   libsass_3_2:
     support: false
     tests:
@@ -602,11 +602,11 @@ reserved_function_names:
       tests/reserved_function_names/and: false
       tests/reserved_function_names/or: false
   ruby_sass_3_4:
-    support: false
+    support: true
     tests:
-      tests/reserved_function_names/not: false
-      tests/reserved_function_names/and: false
-      tests/reserved_function_names/or: false
+      tests/reserved_function_names/not: true
+      tests/reserved_function_names/and: true
+      tests/reserved_function_names/or: true
   libsass_3_1:
     support: false
     tests:
@@ -614,11 +614,11 @@ reserved_function_names:
       tests/reserved_function_names/and: false
       tests/reserved_function_names/or: false
   libsass_3_2:
-    support: false
+    support: true
     tests:
-      tests/reserved_function_names/not: false
-      tests/reserved_function_names/and: false
-      tests/reserved_function_names/or: false
+      tests/reserved_function_names/not: true
+      tests/reserved_function_names/and: true
+      tests/reserved_function_names/or: true
 
 selector_manipulation_functions:
   ruby_sass_3_2:

--- a/_data/support.yml
+++ b/_data/support.yml
@@ -15,6 +15,10 @@ ampersand_sassscript:
     support: false
     tests:
       tests/ampersand_sassscript: false
+  libsass_3_2:
+    support: true
+    tests:
+      tests/ampersand_sassscript: true
 
 angle_conversion:
   ruby_sass_3_2:
@@ -30,6 +34,10 @@ angle_conversion:
     tests:
       spec/libsass-closed-issues/issue_666/angle: true
   libsass_3_1:
+    support: true
+    tests:
+      spec/libsass-closed-issues/issue_666/angle: true
+  libsass_3_2:
     support: true
     tests:
       spec/libsass-closed-issues/issue_666/angle: true
@@ -111,6 +119,25 @@ at_root_directive:
       spec/libsass/at-root/141_test_at_root_with_parent_ref: false
       spec/libsass/at-root/142_test_multi_level_at_root_with_parent_ref: false
       spec/libsass/at-root/143_test_multi_level_at_root_with_inner_parent_ref: false
+  libsass_3_2:
+    support: true
+    tests:
+      spec/libsass/at-root/ampersand: true
+      spec/libsass/at-root/basic: true
+      spec/libsass/at-root/extend: true
+      spec/libsass/at-root/keyframes: true
+      spec/libsass/at-root/media: true
+      spec/libsass/at-root/nested: true
+      spec/libsass/at-root/with_without: true
+      spec/libsass/at-root/135_test_simple_at_root: true
+      spec/libsass/at-root/136_test_at_root_with_selector: true
+      spec/libsass/at-root/137_test_at_root_in_mixin: true
+      spec/libsass/at-root/138_test_at_root_in_media: true
+      spec/libsass/at-root/139_test_at_root_in_bubbled_media: true
+      spec/libsass/at-root/140_test_at_root_in_unknown_directive: true
+      spec/libsass/at-root/141_test_at_root_with_parent_ref: true
+      spec/libsass/at-root/142_test_multi_level_at_root_with_parent_ref: true
+      spec/libsass/at-root/143_test_multi_level_at_root_with_inner_parent_ref: true
 
 call_function:
   ruby_sass_3_2:
@@ -126,6 +153,10 @@ call_function:
     tests:
       spec/basic/60_call: true
   libsass_3_1:
+    support: true
+    tests:
+      spec/basic/60_call: true
+  libsass_3_2:
     support: true
     tests:
       spec/basic/60_call: true
@@ -147,6 +178,10 @@ cross_media_extend:
     support: false
     tests:
       tests/cross_media_extend: false
+  libsass_3_2:
+    support: false
+    tests:
+      tests/cross_media_extend: false
 
 deep_extend:
   ruby_sass_3_2:
@@ -165,6 +200,10 @@ deep_extend:
     support: false
     tests:
       spec/libsass-closed-issues/issue_592: false
+  libsass_3_2:
+    support: true
+    tests:
+      spec/libsass-closed-issues/issue_592: true
 
 downward_for:
   ruby_sass_3_2:
@@ -183,6 +222,10 @@ downward_for:
     support: true
     tests:
       spec/libsass-closed-issues/issue_703: true
+  libsass_3_2:
+    support: true
+    tests:
+      spec/libsass-closed-issues/issue_703: true
 
 error_directive:
   ruby_sass_3_2:
@@ -198,6 +241,10 @@ error_directive:
     tests:
       tests/error_directive: false
   libsass_3_1:
+    support: false
+    tests:
+      tests/error_directive: false
+  libsass_3_2:
     support: false
     tests:
       tests/error_directive: false
@@ -235,6 +282,14 @@ feature_detection_functions:
       spec/basic/56_global_variable_exists: true
       spec/basic/57_function_exists: true
       spec/basic/58_mixin_exists: true
+  libsass_3_2:
+    support: true
+    tests:
+      spec/libsass-closed-issues/issue_702: true
+      spec/basic/55_variable_exists: true
+      spec/basic/56_global_variable_exists: true
+      spec/basic/57_function_exists: true
+      spec/basic/58_mixin_exists: true
 
 fixed_if_function:
   ruby_sass_3_2:
@@ -250,6 +305,10 @@ fixed_if_function:
     tests:
       spec/libsass-closed-issues/issue_338: true
   libsass_3_1:
+    support: true
+    tests:
+      spec/libsass-closed-issues/issue_338: true
+  libsass_3_2:
     support: true
     tests:
       spec/libsass-closed-issues/issue_338: true
@@ -271,6 +330,10 @@ inspect_function:
     support: true
     tests:
       spec/libsass-closed-issues/issue_701: true
+  libsass_3_2:
+    support: true
+    tests:
+      spec/libsass-closed-issues/issue_701: true
 
 list_separator_function:
   ruby_sass_3_2:
@@ -286,6 +349,10 @@ list_separator_function:
     tests:
       spec/libsass-closed-issues/issue_506: true
   libsass_3_1:
+    support: true
+    tests:
+      spec/libsass-closed-issues/issue_506: true
+  libsass_3_2:
     support: true
     tests:
       spec/libsass-closed-issues/issue_506: true
@@ -319,6 +386,15 @@ map_data_type:
       spec/maps/map-remove: true
       spec/maps/map-values: true
   libsass_3_1:
+    support: true
+    tests:
+      spec/maps/map-get: true
+      spec/maps/map-has-key: true
+      spec/maps/map-keys: true
+      spec/maps/map-merge: true
+      spec/maps/map-remove: true
+      spec/maps/map-values: true
+  libsass_3_2:
     support: true
     tests:
       spec/maps/map-get: true
@@ -365,6 +441,15 @@ media_merge:
       spec/libsass-closed-issues/issue_185/merge_no_repeat: false
       spec/libsass-closed-issues/issue_185/mixin: false
       spec/libsass-closed-issues/issue_185/selector_wrapper_media: false
+  libsass_3_2:
+    support: true
+    tests:
+      spec/libsass-closed-issues/issue_185/hoisting: true
+      spec/libsass-closed-issues/issue_185/media_level_4: true
+      spec/libsass-closed-issues/issue_185/media_wrapper_selector: true
+      spec/libsass-closed-issues/issue_185/merge_no_repeat: true
+      spec/libsass-closed-issues/issue_185/mixin: true
+      spec/libsass-closed-issues/issue_185/selector_wrapper_media: true
 
 multi_assign_each:
   ruby_sass_3_2:
@@ -380,6 +465,10 @@ multi_assign_each:
     tests:
       spec/libsass-closed-issues/issue_492: true
   libsass_3_1:
+    support: true
+    tests:
+      spec/libsass-closed-issues/issue_492: true
+  libsass_3_2:
     support: true
     tests:
       spec/libsass-closed-issues/issue_492: true
@@ -401,6 +490,10 @@ multi_keys_map_remove:
     support: true
     tests:
       spec/libsass-closed-issues/issue_510: true
+  libsass_3_2:
+    support: true
+    tests:
+      spec/libsass-closed-issues/issue_510: true
 
 negative_indexes:
   ruby_sass_3_2:
@@ -416,6 +509,10 @@ negative_indexes:
     tests:
       spec/libsass-closed-issues/issue_224: true
   libsass_3_1:
+    support: true
+    tests:
+      spec/libsass-closed-issues/issue_224: true
+  libsass_3_2:
     support: true
     tests:
       spec/libsass-closed-issues/issue_224: true
@@ -437,6 +534,10 @@ nested_interpolations:
     support: false
     tests:
       spec/libsass-closed-issues/issue_615: false
+  libsass_3_2:
+    support: true
+    tests:
+      spec/libsass-closed-issues/issue_615: true
 
 random_function:
   ruby_sass_3_2:
@@ -459,6 +560,11 @@ random_function:
     tests:
       spec/libsass-closed-issues/issue_657/limit: true
       spec/libsass-closed-issues/issue_657/default: false
+  libsass_3_2:
+    support: 
+    tests:
+      spec/libsass-closed-issues/issue_657/limit: true
+      spec/libsass-closed-issues/issue_657/default: false
 
 rebeccapurple_color:
   ruby_sass_3_2:
@@ -474,6 +580,10 @@ rebeccapurple_color:
     tests:
       spec/libsass-closed-issues/issue_699: true
   libsass_3_1:
+    support: true
+    tests:
+      spec/libsass-closed-issues/issue_699: true
+  libsass_3_2:
     support: true
     tests:
       spec/libsass-closed-issues/issue_699: true
@@ -503,6 +613,12 @@ reserved_function_names:
       tests/reserved_function_names/not: false
       tests/reserved_function_names/and: false
       tests/reserved_function_names/or: false
+  libsass_3_2:
+    support: false
+    tests:
+      tests/reserved_function_names/not: false
+      tests/reserved_function_names/and: false
+      tests/reserved_function_names/or: false
 
 selector_manipulation_functions:
   ruby_sass_3_2:
@@ -518,6 +634,10 @@ selector_manipulation_functions:
     tests:
       tests/selector_manipulation_functions: true
   libsass_3_1:
+    support: false
+    tests:
+      tests/selector_manipulation_functions: false
+  libsass_3_2:
     support: false
     tests:
       tests/selector_manipulation_functions: false
@@ -539,6 +659,10 @@ set_nth_function:
     support: true
     tests:
       spec/libsass-closed-issues/issue_578: true
+  libsass_3_2:
+    support: true
+    tests:
+      spec/libsass-closed-issues/issue_578: true
 
 shadow_dom_styling:
   ruby_sass_3_2:
@@ -557,6 +681,10 @@ shadow_dom_styling:
     support: false
     tests:
       tests/shadow_dom_styling: false
+  libsass_3_2:
+    support: true
+    tests:
+      tests/shadow_dom_styling: true
 
 spaces_minus:
   ruby_sass_3_2:
@@ -575,6 +703,10 @@ spaces_minus:
     support: false
     tests:
       spec/libsass-closed-issues/issue_733: false
+  libsass_3_2:
+    support: true
+    tests:
+      spec/libsass-closed-issues/issue_733: true
 
 string_manipulation_functions:
   ruby_sass_3_2:
@@ -621,6 +753,17 @@ string_manipulation_functions:
       spec/libsass-closed-issues/issue_760: true
       spec/libsass-closed-issues/issue_763: true
       spec/libsass-closed-issues/issue_815: false
+  libsass_3_2:
+    support: 
+    tests:
+      spec/basic/43_str_length: true
+      spec/basic/45_str_insert: true
+      spec/basic/46_str_index: true
+      spec/basic/48_case_conversion: true
+      spec/libsass-todo-tests/47_str_slice: false
+      spec/libsass-closed-issues/issue_760: true
+      spec/libsass-closed-issues/issue_763: true
+      spec/libsass-closed-issues/issue_815: true
 
 transparent_color:
   ruby_sass_3_2:
@@ -636,6 +779,10 @@ transparent_color:
     tests:
       spec/libsass-closed-issues/issue_700: true
   libsass_3_1:
+    support: true
+    tests:
+      spec/libsass-closed-issues/issue_700: true
+  libsass_3_2:
     support: true
     tests:
       spec/libsass-closed-issues/issue_700: true
@@ -657,6 +804,10 @@ unique_id_function:
     support: true
     tests:
       spec/libsass-closed-issues/issue_636: true
+  libsass_3_2:
+    support: true
+    tests:
+      spec/libsass-closed-issues/issue_636: true
 
 variable_scoping:
   ruby_sass_3_2:
@@ -675,4 +826,8 @@ variable_scoping:
     support: false
     tests:
       spec/libsass-closed-issues/issue_613: false
+  libsass_3_2:
+    support: true
+    tests:
+      spec/libsass-closed-issues/issue_613: true
 

--- a/_data/tests.yml
+++ b/_data/tests.yml
@@ -31,7 +31,7 @@ cross_media_extend:
 # Switch to sass-spec's test once it exists
 
 deep_extend:
-  - spec/libsass-todo-issues/issue_592
+  - spec/libsass-closed-issues/issue_592
 
 downward_for:
   - spec/libsass-closed-issues/issue_703
@@ -82,7 +82,7 @@ negative_indexes:
   - spec/libsass-closed-issues/issue_224
 
 nested_interpolations:
-  - spec/libsass-todo-issues/issue_615
+  - spec/libsass-closed-issues/issue_615
 
 random_function:
   - spec/libsass-closed-issues/issue_657/limit
@@ -130,4 +130,4 @@ unique_id_function:
   - spec/libsass-closed-issues/issue_636
 
 variable_scoping:
-  - spec/libsass-todo-issues/issue_613
+  - spec/libsass-closed-issues/issue_613

--- a/_sass/utils/_stats.scss
+++ b/_sass/utils/_stats.scss
@@ -1,6 +1,6 @@
 $stats: (
   'ruby_sass_3_2': 12,
-  'ruby_sass_3_3': 88,
-  'ruby_sass_3_4': 100,
-  'libsass': 50,
+  'ruby_sass_3_3': 79,
+  'ruby_sass_3_4': 93,
+  'libsass_3_1': 47,
 );

--- a/_sass/utils/_stats.scss
+++ b/_sass/utils/_stats.scss
@@ -3,4 +3,5 @@ $stats: (
   'ruby_sass_3_3': 79,
   'ruby_sass_3_4': 93,
   'libsass_3_1': 47,
+  'libsass_3_2': 88,
 );

--- a/_sass/utils/_stats.scss
+++ b/_sass/utils/_stats.scss
@@ -1,7 +1,7 @@
 $stats: (
   'ruby_sass_3_2': 12,
   'ruby_sass_3_3': 79,
-  'ruby_sass_3_4': 93,
-  'libsass_3_1': 47,
-  'libsass_3_2': 88,
+  'ruby_sass_3_4': 100,
+  'libsass_3_1': 49,
+  'libsass_3_2': 93,
 );

--- a/tests/cross_media_extend/expected_output.css
+++ b/tests/cross_media_extend/expected_output.css
@@ -1,1 +1,1 @@
-You may not @extend an outer selector from within @media. You may only @extend selectors within the same directive. From "@extend .selector" on line 7.
+You may not @extend an outer selector from within @media. You may only @extend selectors within the same directive. From "@extend .selector" on line 7 of tests/cross_media_extend/input.scss.


### PR DESCRIPTION
This PR replaces the Sassmeister dependencies with docker containers that run locally. Since docker containers are self contained environments running multiple versions of Ruby Sass is easy.

One caveat is that I couldn't get the async runner working with boot2docker so Rake now runs synchronously. ~~This makes Rake run slower but since it only needs to be run infrequently it felt like a good trade for having this site working again.~~

I've also added data for Libsass 3.2.0-beta.5 but I completely understand if you want it removed. Since 3.1.0 has been widely adopted it make sense to keep it around even after 3.2.0 is stable.

### TODO
- [ ] update setup documentation
- [x] clean up remnants of async code
- [x] handle specs where error is a success condition
- [x] update support and stats for the latest sass spec

### Testing it out

To test this out you need to install [VirtualBox](https://www.virtualbox.org/wiki/Downloads).

You'll also need docker and boot2docker. I recommend using brew on OSX.
```
brew install docker boot2docker
boot2docker init
boot2docker up
```
Then just run it as usual
```
bundle install
bundle exec rake clean default
```

**Update**
I was able to get parallelisms working again. However after some benchmarking it turns out (atleast on my machine) the tests run faster without it. I expect this is due to the resource contention of the host VM. I expect this can be tweaked but IMO sticking with the defaults is the way to go for the sake of simplicity.