### PR TITLE
Use Libsass@3.2.0-beta.6

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -133,7 +133,7 @@ DOCKER_ENGINES = {
   :ruby_sass_3_3 => 'xzyfer/docker-ruby-sass:3.3',
   :ruby_sass_3_4 => 'xzyfer/docker-ruby-sass:3.4',
   :libsass_3_1 => 'xzyfer/docker-libsass:3.1.0',
-  :libsass_3_2 => 'xzyfer/docker-libsass:3.2.0-beta.5',
+  :libsass_3_2 => 'xzyfer/docker-libsass:3.2.0-beta.6',
 }
 
 #


### PR DESCRIPTION
This PR updates the Libsass engine to 3.2.0-beta.6. Ideally we could just depend on xzyfer/docker-libsass:beta but due to poor design decision on my behalf this isn't currently possible.

This will be addressed once 3.2.0 is stable.